### PR TITLE
DEV-28 | upgrade vagrant with fixed tested version of vagrant and virtualbox

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -42,7 +42,7 @@ Or Manual Installation
 
 You need to finish 2 (or 3 on Windows) following required simple steps:
 
-1. Install **latest** ``vagrant`` version at: http://downloads.vagrantup.com/
+1. Install ``vagrant`` with the version of **1.2.7** at: http://downloads.vagrantup.com/tags/v1.2.7
 
 2. Install ``virtualbox`` with the version of **4.2.10** at:
    https://www.virtualbox.org/wiki/Download_Old_Builds_4_2
@@ -50,17 +50,13 @@ You need to finish 2 (or 3 on Windows) following required simple steps:
 3. [**Required on Windows only**] Install latest ``git`` version at http://git-scm.com/ to use
    ``Git Bash`` as a terminal.
 
+Notice: You need to install exactly ``vagrant`` **v1.2.7** and ``virtualbox`` **v4.2.10** as it
+was stable enough with our intensive usage and support. We use and run 64 bit architecture every
+day, however, 32 bit archirecture is expected to work, too.
+
+
 Environment Up
 --------------
-
-From your home directory (``~/``), download or clone ``dev`` repository and ``$ vagrant up``. You
-should prepare yourself a cup of coffee as for the first time it could take a little long time
-(~20-30 mins with internet speed ~700-800KB/s) to finish ``$ vagrant up``.
-
-Note: The home directory on ``Git Bash`` normally should point to your user's directory on Windows.
-For example: ``C:\Documents and Settings\<user_name>``, this is the place you will find
-``teracy-dev`` directory to import projects into your text editor later for coding.
-
 
 - Have ``git`` installed:
 Open your terminal window and type:
@@ -71,13 +67,18 @@ Open your terminal window and type:
     $ vagrant up
 
 - Or no ``git`` installed:
-Download the repository at https://github.com/teracy-official/teracy-dev/archive/master.zip and
+Download the repository at https://github.com/teracy-official/dev/archive/master.zip and
 unzip with named ``teracy-dev`` at ``~/`` (*unix) or ``C:\Documents and Settings\<user_name>``
 (Windows). Then open your terminal window:
 ::
     $ cd ~/
     $ cd teracy-dev
     $ vagrant up
+
+
+Note: The home directory on ``Git Bash`` normally should point to your user's directory on Windows.
+For example: ``C:\Documents and Settings\<user_name>``, this is the place you will find
+``teracy-dev`` directory to import projects into your text editor later for coding.
 
 
 You should see the following similar messages at the end of ``$ vagrant up``:

--- a/scripts/setup_working_env_chef.sh
+++ b/scripts/setup_working_env_chef.sh
@@ -19,7 +19,7 @@ fi
 
 is_32_bit=true
 virtualbox_link=http://download.virtualbox.org/virtualbox/4.2.10/virtualbox-4.2_4.2.10-84104~Ubuntu~precise_i386.deb
-vagrant_link=http://files.vagrantup.com/packages/7e400d00a3c5a0fdf2809c8b5001a035415a607b/vagrant_1.2.2_i686.deb
+vagrant_link=http://files.vagrantup.com/packages/7ec0ee1d00a916f80b109a298bab08e391945243/vagrant_1.2.7_i686.deb
 
 function determine_32_64_bit() {
     local machine=$(uname -m)
@@ -33,7 +33,7 @@ determine_32_64_bit
 if ! $is_32_bit ; then
     echo "installing packages of 64-bit virtualbox and vagrant..."
     virtualbox_link=http://download.virtualbox.org/virtualbox/4.2.10/virtualbox-4.2_4.2.10-84104~Ubuntu~precise_amd64.deb
-    vagrant_link=http://files.vagrantup.com/packages/7e400d00a3c5a0fdf2809c8b5001a035415a607b/vagrant_1.2.2_x86_64.deb
+    vagrant_link=http://files.vagrantup.com/packages/7ec0ee1d00a916f80b109a298bab08e391945243/vagrant_1.2.7_x86_64.deb
 fi
 
 
@@ -59,4 +59,3 @@ sudo apt-get update
 install_git
 install_virtualbox
 install_vagrant
-


### PR DESCRIPTION
support vagrant v1.2.7 and virtualbox v4.2.10
