### PR TITLE
DEV-42 | optional add pip index-url of teracy's public pypi to pip-config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -106,9 +106,17 @@ Vagrant.configure("2") do |config|
             "prompt" => false
           }
         },
-        "platform" => {
-          "python" => true, # python platform development, true by default
-          "ruby" => false # ruby platform development, false by default
+        "python" => {
+          "enabled" => true, # python platform development, enabled by default
+          "pip" => {
+            "global" => {
+              #"index-url" => "http://pypi.teracy.org/teracy/public/+simple/"
+            }
+
+          }
+        },
+        "ruby" => {
+          "enabled" => false # ruby platform development, disabled by default
         },
         "gettext" => false # false by default
       },

--- a/config/rake.rb
+++ b/config/rake.rb
@@ -6,7 +6,7 @@
 ###
 
 # The company name - used for SSL certificates, and in srvious other places
-COMPANY_NAME = "Teracy Inc"
+COMPANY_NAME = "Teracy, Inc."
 
 # The Country Name to use for SSL Certificates
 SSL_COUNTRY_NAME = "VN"
@@ -25,7 +25,7 @@ SSL_EMAIL_ADDRESS = "devops@teracy.com"
 
 # License for new Cookbooks
 # Can be :apachev2 or :none
-NEW_COOKBOOK_LICENSE = :apachev2
+NEW_COOKBOOK_LICENSE = :none
 
 ###
 # Useful Extras (which you probably don't need to change)

--- a/docs/ruby_training.rst
+++ b/docs/ruby_training.rst
@@ -9,20 +9,20 @@ Installation
 
 Open ``Vagrantfile`` file and find:
 ::
-    "platform" => {
-      "python" => true,
-      "ruby" => false
-    }
 
-Enable ``ruby`` with: ``"ruby" => true``.
+    "ruby" => {
+      "enabled" => false # ruby platform development, disabled by default
+    },
 
-If you do not want to work with ``python``, disable it with ``"python" => false`` to save provision
-time.
+Enable ``ruby`` with: ``"enabled" => true``.
 
-Then ``$ vagrant reload`` if your VM is already running, or ``$ vagrant up`` if it is not running
+If you do not want to work with ``python``, disable it with ``"python" => "enabled" => false`` to
+save provision time.
+
+Then ``$ vagrant provision`` if your VM is already running, or ``$ vagrant up`` if it is not running
 yet.
 
-After the installation process, you should verify if it works by:
+After the provision process, `$ vagrant ssh` and you should verify if it works by:
 ::
     $ ruby --version
 

--- a/main-cookbooks/teracy-dev/attributes/default.rb
+++ b/main-cookbooks/teracy-dev/attributes/default.rb
@@ -24,18 +24,29 @@ default['teracy-dev']['git'] = {
     }
 }
 
-default['teracy-dev']['platform'] = {
-    'python' => true,
-    'ruby' => false
+
+
+
+default['teracy-dev']['python'] = {
+    'enabled' => true,
+    'pip' => {
+        'global' => {
+            #'index-url' => 'http://pypi.teracy.org/teracy/public/+simple/'
+        }
+    }
+}
+
+default['teracy-dev']['ruby'] = {
+    'enabled' => false
 }
 
 default['teracy-dev']['gettext'] = false
 
-if node['teracy-dev']['platform']['python']
+if node['teracy-dev']['python']['enabled']
     override['python']['setuptools_script_url'] = 'https://bitbucket.org/pypa/setuptools/raw/1.0/ez_setup.py'
 end
 
-if node['teracy-dev']['platform']['ruby']
+if node['teracy-dev']['ruby']['enabled']
     # ruby installation configuration
     override['rbenv']['install_prefix'] = '/home/vagrant'
     override['rbenv']['user']           = 'vagrant'

--- a/main-cookbooks/teracy-dev/metadata.rb
+++ b/main-cookbooks/teracy-dev/metadata.rb
@@ -1,10 +1,10 @@
 name             'teracy-dev'
-maintainer       'Teracy Inc'
+maintainer       'Teracy, Inc.'
 maintainer_email 'hoatlevan@gmail.com'
 license          'All rights reserved'
 description      'Installs/Configures teracy-dev'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.2.0'
 
 depends          'python'
 depends          'magic_shell'
@@ -17,4 +17,5 @@ recipe 'teracy-dev::virtualenvwrapper', 'Installs virtualenvwrapper using the py
 recipe 'teracy-dev::env', 'Configures environment.'
 recipe 'teracy-dev::git-config', 'Configures global git.'
 recipe 'teracy-dev::system-python', 'Installs system-wide Python packages.'
+recipe 'teracy-dev::pip-config', 'Configures global pip.'
 recipe 'teracy-dev::rbenv', 'Installs rbenv and related packages.'

--- a/main-cookbooks/teracy-dev/recipes/alias.rb
+++ b/main-cookbooks/teracy-dev/recipes/alias.rb
@@ -5,19 +5,31 @@
 #
 # Copyright 2013, Teracy, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
 
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+
+#     3. Neither the name of Teracy, Inc. nor the names of its contributors may be used
+#        to endorse or promote products derived from this software without
+#        specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
 
 magic_shell_alias 'ws' do
     command 'cd ~/workspace'

--- a/main-cookbooks/teracy-dev/recipes/apt.rb
+++ b/main-cookbooks/teracy-dev/recipes/apt.rb
@@ -5,18 +5,32 @@
 #
 # Copyright 2013, Teracy, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+
+#     3. Neither the name of Teracy, Inc. nor the names of its contributors may be used
+#        to endorse or promote products derived from this software without
+#        specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+
 %w{tree}.each do |pkg|
     apt_package pkg do
         action:install

--- a/main-cookbooks/teracy-dev/recipes/default.rb
+++ b/main-cookbooks/teracy-dev/recipes/default.rb
@@ -5,18 +5,32 @@
 #
 # Copyright 2013, Teracy, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+
+#     3. Neither the name of Teracy, Inc. nor the names of its contributors may be used
+#        to endorse or promote products derived from this software without
+#        specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+
 include_recipe 'teracy-dev::apt'
 include_recipe 'teracy-dev::workspace'
 include_recipe 'teracy-dev::alias'

--- a/main-cookbooks/teracy-dev/recipes/env.rb
+++ b/main-cookbooks/teracy-dev/recipes/env.rb
@@ -3,21 +3,34 @@
 # Cookbook Name:: teracy-dev
 # Recipe:: env
 # Description: Configures environment
+#
 # Copyright 2013, Teracy, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
 
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+
+#     3. Neither the name of Teracy, Inc. nor the names of its contributors may be used
+#        to endorse or promote products derived from this software without
+#        specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
 
 magic_shell_environment 'EDITOR' do
     value 'vim'

--- a/main-cookbooks/teracy-dev/recipes/git-config.rb
+++ b/main-cookbooks/teracy-dev/recipes/git-config.rb
@@ -6,17 +6,30 @@
 #
 # Copyright 2013, Teracy, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+
+#     3. Neither the name of Teracy, Inc. nor the names of its contributors may be used
+#        to endorse or promote products derived from this software without
+#        specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
 template '/home/vagrant/.gitconfig' do

--- a/main-cookbooks/teracy-dev/recipes/pip-config.rb
+++ b/main-cookbooks/teracy-dev/recipes/pip-config.rb
@@ -1,7 +1,8 @@
 #
 # Author:: Hoat Le <hoatlevan@gmail.com>
 # Cookbook Name:: teracy-dev
-# Recipe:: workspace
+# Recipe:: pip-config
+# Description: Configures global pip
 #
 # Copyright 2013, Teracy, Inc.
 #
@@ -31,11 +32,18 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-node['teracy-dev']['workspace'].each do |dir|
-    directory dir do
-        owner 'vagrant'
-        group 'vagrant'
-        mode 00755
-        action:create
-    end
+directory '/home/vagrant/.pip/' do
+    owner 'vagrant'
+    group 'vagrant'
+    mode 00755
+    action:create
+    only_if { node['teracy-dev']['python']['enabled'] }
+end
+
+template '/home/vagrant/.pip/pip.conf' do
+    source 'pipconfig.erb'
+    owner 'vagrant'
+    group 'vagrant'
+    mode '0664'
+    only_if { node['teracy-dev']['python']['enabled'] }
 end

--- a/main-cookbooks/teracy-dev/recipes/python.rb
+++ b/main-cookbooks/teracy-dev/recipes/python.rb
@@ -6,20 +6,33 @@
 #
 # Copyright 2013, Teracy, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+
+#     3. Neither the name of Teracy, Inc. nor the names of its contributors may be used
+#        to endorse or promote products derived from this software without
+#        specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-if node['teracy-dev']['platform']['python']
+if node['teracy-dev']['python']['enabled']
     include_recipe 'python::default'
 
 #    %w{libpq-dev python-dev}.each do |pkg|
@@ -30,5 +43,6 @@ if node['teracy-dev']['platform']['python']
 
     include_recipe 'teracy-dev::virtualenvwrapper'
     include_recipe 'teracy-dev::system-python'
+    include_recipe 'teracy-dev::pip-config'
 end
 

--- a/main-cookbooks/teracy-dev/recipes/rbenv.rb
+++ b/main-cookbooks/teracy-dev/recipes/rbenv.rb
@@ -5,20 +5,33 @@
 #
 # Copyright 2013, Teracy, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+
+#     3. Neither the name of Teracy, Inc. nor the names of its contributors may be used
+#        to endorse or promote products derived from this software without
+#        specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-if node['teracy-dev']['platform']['ruby']
+if node['teracy-dev']['ruby']['enabled']
 
     include_recipe 'rbenv::default'
     include_recipe 'rbenv::ruby_build'

--- a/main-cookbooks/teracy-dev/recipes/system-python.rb
+++ b/main-cookbooks/teracy-dev/recipes/system-python.rb
@@ -6,19 +6,32 @@
 #
 # Copyright 2013, Teracy, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+
+#     3. Neither the name of Teracy, Inc. nor the names of its contributors may be used
+#        to endorse or promote products derived from this software without
+#        specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
 python_pip 'Sphinx' do
-  action :install
+    action :install
 end

--- a/main-cookbooks/teracy-dev/recipes/virtualenvwrapper.rb
+++ b/main-cookbooks/teracy-dev/recipes/virtualenvwrapper.rb
@@ -5,17 +5,30 @@
 #
 # Copyright 2013, Teracy, Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+
+#     3. Neither the name of Teracy, Inc. nor the names of its contributors may be used
+#        to endorse or promote products derived from this software without
+#        specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
 python_pip 'virtualenvwrapper' do

--- a/main-cookbooks/teracy-dev/templates/default/pipconfig.erb
+++ b/main-cookbooks/teracy-dev/templates/default/pipconfig.erb
@@ -1,0 +1,4 @@
+[global]
+<% if node['teracy-dev']['python']['pip']['global']['index-url'] %>
+index-url = <%= node['teracy-dev']['python']['pip']['global']['index-url'] %>
+<% end %>


### PR DESCRIPTION
- breaking changes: platform => {python, ruby} to python => enabled and ruby => enabled
- pip-config recipe is new introduced
- update LICENSE header

Details: https://issues.teracy.org/browse/DEV-42
