### PR TITLE
DEV-54: Upgrade support for vagrant and virtualbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,9 +32,8 @@ Vagrant.configure("2") do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
-  config.vm.synced_folder "./workspace", "/home/vagrant/workspace"
-  config.vm.synced_folder "./home/.virtualenvs", "/home/vagrant/.virtualenvs"
-  config.vm.synced_folder "./home/.ssh", "/home/vagrant/.ssh", :extra => 'dmode=775,fmode=600'
+  config.vm.synced_folder "./workspace", "/home/vagrant/workspace", :mount_options => ['dmode=777','fmode=777']
+  config.vm.synced_folder "./home/.ssh", "/home/vagrant/.ssh", :mount_options => ['dmode=775','fmode=600']
 
   # ssh configuration
   # config.ssh.forward_agent = true
@@ -43,6 +42,7 @@ Vagrant.configure("2") do |config|
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:
 
+  
   config.vm.provider :virtualbox do |vb|
     # Don't boot with headless mode
     # vb.gui = true


### PR DESCRIPTION
- Upgrade support for vagrant 1.5.1, virtualbox 4.3.8 AND vagrant 1.5.4, virtualbox 4.3.10
- Pls note that virtualbox has an installation issue which is reported here ( https://www.virtualbox.org/ticket/4140 ). If you $ vagrant up but can not start virtual box, pls find "VBoxUSBMon.inf" & "VBoxDrv.inf" in your installation directory and re-install it, it will fix the issues.
