### PR TITLE
DEV-172 | use default memory setting of vagrant instead of current 2048

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -166,7 +166,7 @@ Vagrant.configure("2") do |config|
     # vb.gui = true
 
     # Use VBoxManage to customize the VM. For example to change memory:
-    vb.customize ["modifyvm", :id, "--memory", "2048"]
+    # vb.customize ["modifyvm", :id, "--memory", "2048"]
   end
 
   # Enable provisioning with chef solo, specifying a cookbooks path, roles


### PR DESCRIPTION
Details: https://issues.teracy.org/browse/DEV-172
