### PR TITLE
DEV-175 | Set default VM memory is 512MB instead of default 318MB

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -166,7 +166,7 @@ Vagrant.configure("2") do |config|
     # vb.gui = true
 
     # Use VBoxManage to customize the VM. For example to change memory:
-    # vb.customize ["modifyvm", :id, "--memory", "2048"]
+    vb.customize ["modifyvm", :id, "--memory", "512"]
   end
 
   # Enable provisioning with chef solo, specifying a cookbooks path, roles


### PR DESCRIPTION
This is required for mysql import to work with a big .sql file.

Details: https://issues.teracy.org/browse/DEV-175
