### PR TITLE
DEV-177 | Avoid using vagrant 1.7.2 for now, use 1.7.1 instead

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,32 +39,13 @@ For example, override the ``vm_forwarded_ports`` and ``java`` keys as follows.
 ::
 
   {
-    "vm_forwarded_ports":[
-      {
-        "guest":8000,
-        "host":8000
-      },
-      {
-        "guest":4000,
-        "host":4000
-      },
-      {
-        "guest":3000,
-        "host":3000
-      }
-    ],
-
     "chef_json":{
-   // Config git for virtualbox
-      "git":{
-        "user":{
-          "name":"Hoa Vu",
-          "email":"hoavu@teracy.com"
-        }
-      },
       "teracy-dev":{
-        "java":{
-           "enabled":true
+        "git":{
+          "user":{
+            "name":"hoavt",
+            "email":"hoavt@teracy.com"
+          }
         }
       }
     }

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -49,11 +49,11 @@ Manual Installation
 
 1. Install the latest ``git`` version at http://git-scm.com/.
 
-2. Install ``virtualbox`` with the version of **4.3.20** at
+2. Install ``virtualbox`` with the exact version of **4.3.20** at
    https://www.virtualbox.org/wiki/Downloads.
 
-3. Install ``vagrant`` with the version of **1.7.2** or newer at
-   http://www.vagrantup.com/downloads.html.
+3. Install ``vagrant`` with the exact version of **1.7.1** at
+   https://www.vagrantup.com/download-archive/v1.7.1.html.
 
 **Notice**:
 

--- a/scripts/setup_vagrant_and_virtualbox.bat
+++ b/scripts/setup_vagrant_and_virtualbox.bat
@@ -137,7 +137,7 @@ echo --- DOWNLOAD and INSTALL VAGRANT ---
 echo.
 
 copy /y NUL c:\vgrant.msi >NUL
-powershell -ExecutionPolicy RemoteSigned -File "c:\dp.ps1" "https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2.msi" "c:\vgrant.msi"
+powershell -ExecutionPolicy RemoteSigned -File "c:\dp.ps1" "https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.1.msi" "c:\vgrant.msi"
 
 echo Vagrant is installing
 start /wait /b C:\vgrant.msi

--- a/scripts/setup_working_env_chef.sh
+++ b/scripts/setup_working_env_chef.sh
@@ -4,7 +4,7 @@
 #
 # install git
 # install virtualbox-4.3.20
-# install vagrant 1.7.2
+# install vagrant 1.7.1
 
 function command_exists() {
     type "$1" &> /dev/null;
@@ -19,7 +19,7 @@ if [[ "$distributor_id" != *Ubuntu* ]]; then
 fi
 
 code_name=$(lsb_release -a 2>&1 | grep Codename | awk '{print $2}')
-vagrant_version="1.7.2"
+vagrant_version="1.7.1"
 
 if [ "$code_name" == "trusty" ] || [ "$code_name" == "saucy" ] || [ "$code_name" == "utopic" ]; then
     vbox_download_code_name="raring"


### PR DESCRIPTION
Due to these problems:
- https://github.com/mitchellh/vagrant/issues/5199
- https://github.com/mitchellh/vagrant/issues/5200

Details: https://issues.teracy.org/browse/DEV-177
