### PR TITLE
DEV-195 | By default use fmode=755 instead of fmode=644 for workspace directory

### DIFF
--- a/vagrant_config.json
+++ b/vagrant_config.json
@@ -45,7 +45,7 @@
       "guest":"/home/vagrant/workspace",
       "mount_options":[
         "dmode=775",
-        "fmode=664"
+        "fmode=755"
       ]
     }
     //disable .virtualenvs mapping due to this: https://issues.teracy.org/browse/DEV-116


### PR DESCRIPTION
Details: https://issues.teracy.org/browse/DEV-195
