### PR TITLE
@ #257 | should remove the duplicated entry on the hosts file on the guest VM machine

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -362,6 +362,16 @@ Vagrant.configure("2") do |config|
     end
   end
 
+  # fix hosts file on the guest machine
+  # see: https://github.com/devopsgroup-io/vagrant-hostmanager/issues/203
+  fix_hosts_command = "sed -i \"s/\\(127.0.0.1.*\\)#{config.vm.hostname}\\(.*\\)/\\1\\2/\" /etc/hosts"
+
+  provisioners.unshift({
+    "type" => "shell",
+    "name" => "fix-hosts",
+    "inline" => fix_hosts_command
+  })
+
   # append ip shell as the last item to always display the ip address
   provisioners << {
     "type" => "shell",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -364,7 +364,7 @@ Vagrant.configure("2") do |config|
 
   # fix hosts file on the guest machine
   # see: https://github.com/devopsgroup-io/vagrant-hostmanager/issues/203
-  fix_hosts_command = "sed -i \"s/\\(127.0.0.1.*\\)#{config.vm.hostname}\\(.*\\)/\\1\\2/\" /etc/hosts"
+  fix_hosts_command = "sed -i \"s/\\(127.0.0.1\\)\\(.*\\)#{config.vm.hostname}\\(.*\\)/\\1\\3/\" /etc/hosts"
 
   provisioners.unshift({
     "type" => "shell",


### PR DESCRIPTION
connects #257 

this PR is currently acceptable:

```
$ cat /etc/hosts
127.0.0.1		teracy-2
127.0.0.1	localhost
```

The expected output below is great, can you recommend how to make this great @phuonglm?

```
$ cat /etc/hosts
127.0.0.1	teracy-2
127.0.0.1	localhost
```
