### PR TITLE
should update the teracy-dev git remote repos even when location['sync'] is false

### DIFF
--- a/lib/teracy-dev/loader.rb
+++ b/lib/teracy-dev/loader.rb
@@ -56,12 +56,10 @@ module TeracyDev
       })
       @logger.debug("location: #{location}")
 
-      if Util.true?(location['sync'])
-        if Location::Manager.sync(location) == true
-          # reload
-          @logger.info("reloading...")
-          exec "vagrant #{ARGV.join(" ")}"
-        end
+      if Location::Manager.sync(location, location['sync']) == true
+        # reload
+        @logger.info("reloading...")
+        exec "vagrant #{ARGV.join(" ")}"
       end
     end
 


### PR DESCRIPTION
```yaml
teracy-dev:

  location:
    git:
      remote:
        origin: git@github.com:hoatle/teracy-dev.git
        upstream: git@github.com:teracyhq/dev.git
        test: git@github.com:hoatle/teracy-dev.git
```

with the above config:
expected: `$ vagrant status` should create 3 remote repos.

actual: it did not